### PR TITLE
Fix for console output formatting and MP4s where the channel layout is unknown

### DIFF
--- a/Common/Util.cpp
+++ b/Common/Util.cpp
@@ -25,7 +25,32 @@
 #include <regex>
 #include "Util.hpp"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 namespace util {
+
+	void enableAnsiSupport() {
+#ifdef _WIN32
+		HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+		if (hOut != INVALID_HANDLE_VALUE) {
+			DWORD dwMode = 0;
+			if (GetConsoleMode(hOut, &dwMode)) {
+				dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+				SetConsoleMode(hOut, dwMode);
+			}
+		}
+		hOut = GetStdHandle(STD_ERROR_HANDLE);
+		if (hOut != INVALID_HANDLE_VALUE) {
+			DWORD dwMode = 0;
+			if (GetConsoleMode(hOut, &dwMode)) {
+				dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+				SetConsoleMode(hOut, dwMode);
+			}
+		}
+#endif
+	}
 
 	void ConsoleTimer::interval(const std::string& name) {
 		auto interval = std::chrono::steady_clock::now();

--- a/Common/Util.hpp
+++ b/Common/Util.hpp
@@ -52,6 +52,8 @@ namespace util {
         ~ConsoleTimer();
     };
 
+    void enableAnsiSupport();
+
 
     //output sent to this ostream will be suppressed
     class NullOutstream : public std::ostream {

--- a/Deshaker/FFmpegFormatWriter.cpp
+++ b/Deshaker/FFmpegFormatWriter.cpp
@@ -119,6 +119,13 @@ void FFmpegFormatWriter::openFormat(AVCodecID codecId) {
             //https://ffmpeg.org/doxygen/trunk/remuxing_8c-example.html
             osc.outputStream->codecpar->codec_tag = 0;
 
+            if (osc.outputStream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+                osc.outputStream->codecpar->ch_layout.nb_channels > 0 &&
+                osc.outputStream->codecpar->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
+                av_channel_layout_default(&osc.outputStream->codecpar->ch_layout,
+                                          osc.outputStream->codecpar->ch_layout.nb_channels);
+            }
+
         } else if (osc.handling == StreamHandling::STREAM_TRANSCODE) {
             osc.outputStream = createNewStream(fmt_ctx, inStream);
 
@@ -133,6 +140,11 @@ void FFmpegFormatWriter::openFormat(AVCodecID codecId) {
             int retval = avcodec_parameters_to_context(osc.audioInCtx, inStream->codecpar);
             if (retval < 0)
                 throw AVException(av_make_error(retval, "cannot copy audio parameters to input context"));
+
+            if (osc.audioInCtx->ch_layout.nb_channels > 0 && osc.audioInCtx->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
+                av_channel_layout_default(&osc.audioInCtx->ch_layout, osc.audioInCtx->ch_layout.nb_channels);
+            }
+
             retval = avcodec_open2(osc.audioInCtx, osc.audioInCodec, NULL);
             if (retval < 0)
                 throw AVException(av_make_error(retval, "cannot open audio decoder"));

--- a/TestRelease/Main.cpp
+++ b/TestRelease/Main.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "Deshaker.hpp"
+#include "Util.hpp"
 #include <sstream>
 #include <regex>
 #include <filesystem>
@@ -239,6 +240,7 @@ static void testSpeed() {
 }
 
 int main() {
+	util::enableAnsiSupport();
 	std::vector<std::string> folders = { "d:/videoTest/out", "d:/videoTest/out/images" };
 	for (const std::string& folder : folders) {
 		std::cout << "--- Delete " << folder << " ---" << std::endl;

--- a/cuvistaCli/Main.cpp
+++ b/cuvistaCli/Main.cpp
@@ -17,8 +17,10 @@
  */
 
 #include "Deshaker.hpp"
+#include "Util.hpp"
 
 int main(int argsCount, char** args) {
+	util::enableAnsiSupport();
 	std::vector<std::string> argsInput(args + 1, args + argsCount);
 	return deshake(argsInput, &std::cout, {}).statusCode;
 }


### PR DESCRIPTION
I received an error when writing a file via the CLI:
```
ERROR STACK:
[0] error writing trailer: Invalid argument
```
I was using footage from Lumix G9 camera. The MP4 files have PCM audio streams with an **unspecified/unknown channel layout** (`channel_layout=unknown` in ffprobe output, `AV_CHANNEL_ORDER_UNSPEC` in FFmpeg API). When cuvista copied the audio stream parameters using `avcodec_parameters_copy()`, it preserved this unknown channel layout. The resultant files were unplayable and/or had no audio.

I have added a fix that sets the output audio channels.
Also I was finding console output had escape characters and other things in it, so there's a fix for this.

BTW this is a wonderful program! Thanks for making it!